### PR TITLE
add slash to wp method

### DIFF
--- a/includes/Options.php
+++ b/includes/Options.php
@@ -49,7 +49,7 @@ class Options {
 	 * @return array
 	 */
 	public function fetch() {
-		return (array) get_option( $this->optionName, [] );
+		return (array) \get_option( $this->optionName, [] );
 	}
 
 	/**


### PR DESCRIPTION
The wp get_option method is causing issues when running lint in other projects. This should properly scope it.

PHP Fatal error:  Uncaught Error: Call to undefined function WP_Forge\Options\get_option() in /vendor/wp-forge/wp-options/includes/Options.php:52

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [] Bugfix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

<!-- - [] I have read the [CONTRIBUTING](https://github.com/wp-forge/.github/blob/master/.github/CONTRIBUTING.md) doc -->
- [] Linting and tests pass locally with my changes
- [] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
